### PR TITLE
fix: use dumb-init for signal handling in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM python:3.8
 
 # set up the system
 RUN apt update && \
-	apt install --yes nginx sudo && \
+	apt install --yes nginx sudo dumb-init && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/nginx/locations.d
@@ -26,4 +26,5 @@ RUN cp nginx/default /etc/nginx/sites-available/default
 RUN pip install pipenv
 RUN pipenv install --ignore-pipfile --deploy --system
 
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["sh", "-c", "nginx && pipenv run -- flask run -h 0.0.0.0"]


### PR DESCRIPTION
Have a look at dumb init: https://github.com/Yelp/dumb-init

You can now use CTRL+C to quit a docker container
running in foreground.

We can use docker-compose and two containers later on
but this increases complexity and is harder to get started.

fixes #11