### PR TITLE
feat: human readable doc path

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,33 +1,36 @@
-# web
+# docat web
 
 ## Project setup
-```
-yarn install
+
+```sh
+yarn install [--pure-lockfile]
 ```
 
 ### Compiles and hot-reloads for development
 
-Configure the backend connection by setting 
+Configure the backend connection by setting
 port and host in `.env.development.local`.
 Like this configuration for the host `127.0.0.1`
 and the port `1337`.
 
-```
+```sh
 VUE_APP_BACKEND_PORT=1337
 VUE_APP_BACKEND_HOST=127.0.0.1
 ```
 
-```
-yarn serve [--mode development]
+```sh
+yarn serve
 ```
 
 ### Compiles and minifies for production
-```
+
+```sh
 yarn build
 ```
 
 ### Lints and fixes files
-```
+
+```sh
 yarn lint
 ```
 
@@ -36,9 +39,26 @@ yarn lint
 Not happy with the default Docat logo and header?
 Just add your custom html header to the `/var/www/html/config.json` file.
 
-```
-{"headerHTML": "<h1>MyCompany</h1>"}
+```json
+{ "headerHTML": "<h1>MyCompany</h1>" }
 ```
 
 ### Customize configuration
+
 See [Configuration Reference](https://cli.vuejs.org/config/).
+
+
+## Development
+
+To mount the development `dist/` folder while working on the
+web frontend, you can mount the `dist/` folder as a docker volume:
+
+```sh
+sudo docker run \
+  --detach \
+  --volume /path/to/doc:/var/docat/doc/ \
+  --volume /path/to/locations:/etc/nginx/locations.d/ \
+  --volume /path/to/docat/web/dist:/var/www/html/ \
+  --publish 8000:80 \
+  docat
+```

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -52,7 +52,7 @@ import Upload from '@/pages/Upload.vue'
 
 const routes = [
   { path: '/', component: Home },
-  { path: '/:project/:version/:location?', component: Docs },
+  { path: '/:project/:version/:location(.*)?', component: Docs },
   { path: '/help', component: Help },
   { path: '/upload', component: Upload },
 ]

--- a/web/src/repositories/ProjectRepository.js
+++ b/web/src/repositories/ProjectRepository.js
@@ -1,7 +1,8 @@
 import Repository from '@/repositories/Repository'
 
-const resource = 'doc'
 export default {
+
+  resource: 'doc',
 
   /**
   * Get Config
@@ -19,7 +20,7 @@ export default {
    * Returns all projects
    */
   get() {
-    return Repository.get(`${Repository.defaults.baseURL}/${resource}/`)
+    return Repository.get(`${Repository.defaults.baseURL}/${this.resource}/`)
   },
 
   /**
@@ -27,16 +28,34 @@ export default {
    * @param {string} projectName Name of the project
    */
   getProjectLogoURL(projectName) {
-    return `${Repository.defaults.baseURL}/${resource}/${projectName}/logo.jpg`
+    return `${Repository.defaults.baseURL}/${this.resource}/${projectName}/logo.jpg`
   },
 
   /**
    * Returns the project documentatino URL
    * @param {string} projectName Name of the project
    * @param {string} version Version name
+   * @param {string?} docsPath Path to the documentation page
    */
-  getProjectDocsURL(projectName, version) {
-    return `${Repository.defaults.baseURL}/${resource}/${projectName}/${version}/`
+  getProjectDocsURL(projectName, version, docsPath) {
+    return `${Repository.defaults.baseURL}/${this.resource}/${projectName}/${version}/${docsPath || ''}`
+  },
+
+  /**
+   * Returns the docs path only without the prefix, porject and version
+   * @param {string} projectName Name of the project
+   * @param {string} version Version name
+   * @param {string} fullDocsPath Full path to the docs including prefix, project and version
+   */
+  getDocsPath(projectName, version, fullDocsPath) {
+    const match = decodeURIComponent(fullDocsPath).match(new RegExp(
+      String.raw`(.*)/${this.resource}/${projectName}/${version}/(.*)`
+    ))
+    if (match && match.length > 2) {
+      return match[2] || ""
+    } else {
+      return fullDocsPath
+    }
   },
 
   /**
@@ -45,11 +64,17 @@ export default {
    * @param {string} projectName Name of the project
    */
   async getVersions(projectName) {
-    return (await Repository.get(`${Repository.defaults.baseURL}/${resource}/${projectName}/`))
+    return (await Repository.get(`${Repository.defaults.baseURL}/${this.resource}/${projectName}/`))
       .data
       .filter((version) => version.type == 'directory')
   },
 
+  /**
+   * Upload a new project (as zip)
+   * @param {string} projectName Name of the project
+   * @param {string} version Version of the project
+   * @param {formData} formData Zip archive to upload
+   */
   async upload(projectName, version, formData) {
     await Repository.post(
       `${Repository.defaults.baseURL}/api/${projectName}/${version}`,

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -1,5 +1,11 @@
+const path = require('path')
+
 module.exports = {
   configureWebpack: {
+    devServer: {
+      contentBase: path.join(__dirname, 'dist'),
+      writeToDisk: true,
+    },
     module: {
       rules: [{
         test: /\.md$/,


### PR DESCRIPTION
This change provides more human readable document urls. Instead of just adding the whole
url as the 'location' parameter as an urlencoded parameter. Now the 'real path' is taken:

Before:

```
http://docat.local/#/project/0.0.0/http:%2F%2Fdocat.local%2Fdoc%2Fproject%2F0.0.0%2Finstallation%2F
```

Now:

```
http://docat.local/#/project/0.0.0/installation/
```