### PR TITLE
feat(docs): use real url in the help page

### DIFF
--- a/web/src/components/Help.vue
+++ b/web/src/components/Help.vue
@@ -1,6 +1,6 @@
 <template>
   <vue-markdown>
-    {{ help }}
+    {{ help() }}
   </vue-markdown>
 </template>
 
@@ -14,9 +14,15 @@ export default {
   components: {
     VueMarkdown
   },
-  data() {
-    return {
-      help,
+  methods: {
+    help() {
+      const port = process.env.VUE_APP_BACKEND_PORT || location.port
+      const host = process.env.VUE_APP_BACKEND_HOST || location.hostname
+
+      return help.replace(
+        /http:\/\/localhost:8000/g,
+        `${location.protocol}//${host}${port !== '' ? ':' + port : ''}`
+      );
     }
   }
 }


### PR DESCRIPTION
fixes #69, now the help page looks something like this:

![image](https://user-images.githubusercontent.com/5184499/90362652-68079b80-e061-11ea-8bf1-978942e7e739.png)
