### PR TITLE
Revert "Ok github why do you need the old python for your check..."

### DIFF
--- a/.github/workflows/docat.yml
+++ b/.github/workflows/docat.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This reverts commit fcbc7bee9d707b7312a7435edb9545630aa604a5.

can be done because mr @randombenj fixed the github setting 