### PR TITLE
fix(backend): salt can contain non convertable characters

### DIFF
--- a/docat/app.py
+++ b/docat/app.py
@@ -87,7 +87,7 @@ def claim(project):
     token = secrets.token_hex(16)
     salt = os.urandom(32)
     token_hash = calculate_token(token, salt)
-    table.insert({"name": project, "token": token_hash, "salt": salt})
+    table.insert({"name": project, "token": token_hash, "salt": salt.hex()})
 
     return {"message": f"Project {project} successfully claimed", "token": token}, HTTPStatus.CREATED
 
@@ -116,7 +116,7 @@ def check_token_for_project(token, project):
     result = table.search(Project.name == project)
 
     if result and token:
-        token_hash = calculate_token(token, result[0]["salt"])
+        token_hash = calculate_token(token, bytes.fromhex(result[0]["salt"]))
         if result[0]["token"] == token_hash:
             return True
         else:

--- a/docat/docat/utils.py
+++ b/docat/docat/utils.py
@@ -101,6 +101,6 @@ def calculate_token(password, salt):
 
     Args:
         password (str): the password to hash
-        salt (str): the salt used for the password
+        salt (byte): the salt used for the password
     """
-    return hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 100000)
+    return hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 100000).hex()

--- a/docat/tests/conftest.py
+++ b/docat/tests/conftest.py
@@ -24,7 +24,7 @@ def client():
 def client_with_claimed_project(client):
     table = app.db.table("claims")
     token_hash_1234 = b"\xe0\x8cS\xa3)\xb4\xb5\xa5\xda\xc3K\x96\xf6).\xdd-\xacR\x8e3Q\x17\x87\xfb\x94\x0c-\xc2h\x1c\xf3"
-    table.insert({"name": "some-project", "token": token_hash_1234, "salt": b""})
+    table.insert({"name": "some-project", "token": token_hash_1234.hex(), "salt": ""})
     return app.test_client()
 
 


### PR DESCRIPTION
leads to errors like this:
File "/usr/local/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable

because of that all bytes are converted to hex