### PR TITLE
docs: readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ docker run \
   --detach \
   --volume /path/to/doc:/var/docat/doc/ \
   --volume /path/to/locations:/etc/nginx/locations.d/ \
-  --volume /path/to/db.json:/app/docat/db.json
+  --volume /path/to/db.json:/app/docat/db.json \
   --publish 8000:80 \
   randombenj/docat
 ```


### PR DESCRIPTION
 There is a missing `\` in the docker command in the readme.